### PR TITLE
Iterate over lent keys, avoids copying

### DIFF
--- a/stashtable.nim
+++ b/stashtable.nim
@@ -134,7 +134,7 @@ proc `$`*(index: Index): string =
   if index == NotInStash: "NotInStash"
   else: '@' & $index.int
 
-iterator keys*[K, V, Capacity](stash: StashTable[K, V, Capacity]): (K , Index) =
+iterator keys*[K, V, Capacity](stash: StashTable[K, V, Capacity]): (lent K , Index) =
   ## Iterates over all ``(key , index)`` pairs in the table ``stash``.
   ##
   ## feature: if there are no deletes, iteration order is insertion order.


### PR DESCRIPTION
Is this change legitimate? There's no lock here.
It appears to be to me, but I could just be getting lucky with ARC.